### PR TITLE
#ARGB format support

### DIFF
--- a/SAMCategories/UIKit/UIColor+SAMAdditions.h
+++ b/SAMCategories/UIKit/UIColor+SAMAdditions.h
@@ -72,7 +72,7 @@
  
  @return An UIColor object containing a value.
  
- You can specify hex values in the following formats: `rgb`, `rrggbb`, or `rrggbbaa`.
+ You can specify hex values in the following formats: `rgb`, `argb`, `rrggbb`, or `rrggbbaa`.
  
  The default alpha value is `1.0`.
  

--- a/SAMCategories/UIKit/UIColor+SAMAdditions.m
+++ b/SAMCategories/UIKit/UIColor+SAMAdditions.m
@@ -302,8 +302,8 @@
 		hex = [NSString stringWithFormat:@"%@%@%@%@%@%@ff",
 			   r, r, g, g, b, b];
     } else if (length == 4) {
-        NSString *a = [hex substringWithRange:NSMakeRange(0, 1)];
-        NSString *r = [hex substringWithRange:NSMakeRange(1, 1)];
+		NSString *a = [hex substringWithRange:NSMakeRange(0, 1)];
+		NSString *r = [hex substringWithRange:NSMakeRange(1, 1)];
 		NSString *g = [hex substringWithRange:NSMakeRange(2, 1)];
 		NSString *b = [hex substringWithRange:NSMakeRange(3, 1)];
 		hex = [NSString stringWithFormat:@"%@%@%@%@%@%@%@%@",

--- a/SAMCategories/UIKit/UIColor+SAMAdditions.m
+++ b/SAMCategories/UIKit/UIColor+SAMAdditions.m
@@ -288,9 +288,9 @@
 		hex = [hex substringFromIndex:2];
 	}
 	
-	// Invalid if not 3, 6, or 8 characters
+	// Invalid if not 3, 4, 6, or 8 characters
 	NSUInteger length = [hex length];
-	if (length != 3 && length != 6 && length != 8) {
+	if (length != 3 && length != 4 && length != 6 && length != 8) {
 		return nil;
 	}
 	
@@ -301,6 +301,13 @@
 		NSString *b = [hex substringWithRange:NSMakeRange(2, 1)];
 		hex = [NSString stringWithFormat:@"%@%@%@%@%@%@ff",
 			   r, r, g, g, b, b];
+    } else if (length == 4) {
+        NSString *a = [hex substringWithRange:NSMakeRange(0, 1)];
+        NSString *r = [hex substringWithRange:NSMakeRange(1, 1)];
+		NSString *g = [hex substringWithRange:NSMakeRange(2, 1)];
+		NSString *b = [hex substringWithRange:NSMakeRange(3, 1)];
+		hex = [NSString stringWithFormat:@"%@%@%@%@%@%@%@%@",
+			   r, r, g, g, b, b, a, a];
 	} else if (length == 6) {
 		hex = [hex stringByAppendingString:@"ff"];
 	}

--- a/Tests/UIKit/SAMColorCategoryTest.m
+++ b/Tests/UIKit/SAMColorCategoryTest.m
@@ -68,16 +68,19 @@
 - (void)testColorWithHex {
 	UIColor *red = [UIColor redColor];
 	STAssertEqualObjects(red, [UIColor sam_colorWithHex:@"f00"], nil);
+	STAssertEqualObjects(red, [UIColor sam_colorWithHex:@"ff00"], nil);
 	STAssertEqualObjects(red, [UIColor sam_colorWithHex:@"ff0000"], nil);
 	STAssertEqualObjects(red, [UIColor sam_colorWithHex:@"ff0000ff"], nil);
 	
 	UIColor *green = [UIColor greenColor];
 	STAssertEqualObjects(green, [UIColor sam_colorWithHex:@"0f0"], nil);
+	STAssertEqualObjects(green, [UIColor sam_colorWithHex:@"f0f0"], nil);
 	STAssertEqualObjects(green, [UIColor sam_colorWithHex:@"00ff00"], nil);
 	STAssertEqualObjects(green, [UIColor sam_colorWithHex:@"00ff00ff"], nil);
 	
 	UIColor *blue = [UIColor blueColor];
 	STAssertEqualObjects(blue, [UIColor sam_colorWithHex:@"00f"], nil);
+	STAssertEqualObjects(blue, [UIColor sam_colorWithHex:@"f00f"], nil);
 	STAssertEqualObjects(blue, [UIColor sam_colorWithHex:@"0000ff"], nil);
 	STAssertEqualObjects(blue, [UIColor sam_colorWithHex:@"0000ffff"], nil);
 	


### PR DESCRIPTION
This adds [#ARGB](http://en.wikipedia.org/wiki/RGBA_color_space#ARGB) support in `sam_colorWithHex`.

Tests are updated also
