### PR TITLE
Fix translations for NSDate+SAMAdditions

### DIFF
--- a/SAMCategories/SAMCategories.bundle/de.lproj/SAMCategories.strings
+++ b/SAMCategories/SAMCategories.bundle/de.lproj/SAMCategories.strings
@@ -6,14 +6,16 @@
 //  Copyright 2012-2013 Sam Soffes. All rights reserved.
 //
 
-"1s" = "1S";   // one second
+"1s" = "1s";   // one second
 "%ds" = "%ds";   // several seconds
-"1m" = "1M";   // one minutes
+"1m" = "1m";   // one minutes
 "%dm" = "%dm";   // several minutes
-"1h" = "1St";   // one hours
-"%dh" = "%dst";   // several hours
+"1h" = "1h";   // one hours
+"%dh" = "%dh";   // several hours
 "1d" = "1T";   // one day
 "%@d" = "%@T";   // several days
+"1y" = "1J";   // one year
+"%@y" = "%@J";   // several years
 
 "1 minute" = "1 Minute";
 "less than %d seconds" = "weniger als %d Sekunden";

--- a/SAMCategories/SAMCategories.bundle/de.lproj/SAMCategories.strings
+++ b/SAMCategories/SAMCategories.bundle/de.lproj/SAMCategories.strings
@@ -26,7 +26,7 @@
 "about %d hours" = "etwa %d Stunden";
 "1 day" = "1 Tag";
 "%d days" = "%d Tage";
-"about 1 month" = "etwa 1 Tag";
+"about 1 month" = "etwa 1 Monat";
 "%d months" = "%d Monate";
 "about 1 year" = "etwa 1 Jahr";
 "over %d years" = "über %d Jahre";

--- a/SAMCategories/SAMCategories.bundle/en.lproj/SAMCategories.strings
+++ b/SAMCategories/SAMCategories.bundle/en.lproj/SAMCategories.strings
@@ -14,6 +14,8 @@
 "%dh" = "%dh"; // several hours
 "1d" = "1d"; // one day
 "%@d" = "%@d"; // several days
+"1y" = "1y"; // one year
+"%@y" = "%@y"; // several years
 
 "1 minute" = "1 minute";
 "less than %d seconds" = "less than %d seconds";

--- a/SAMCategories/SAMCategories.bundle/ja.lproj/SAMCategories.strings
+++ b/SAMCategories/SAMCategories.bundle/ja.lproj/SAMCategories.strings
@@ -16,7 +16,7 @@
 "%@d" = "%@日";   // several days
 
 "1 minute" = "1分";
-"%d minutes" = "%d秒以下";
+"less than %d seconds" = "%d秒以下";
 "half a minute" = "３０秒";
 "less than a minute" = "1分以下";
 "%d minutes" = "%d分";

--- a/SAMCategories/SAMCategories.bundle/zh_Hans.lproj/SAMCategories.strings
+++ b/SAMCategories/SAMCategories.bundle/zh_Hans.lproj/SAMCategories.strings
@@ -16,15 +16,15 @@
 "%@d" = "%@天";   // several days
 
 "1 minute" = "1 分钟";
-"%d minutes" = "少于 %d 秒";
+"less than %d seconds" = "少于 %d 秒";
 "half a minute" = "半分钟";
 "less than a minute" = "少于一分钟";
 "%d minutes" = "%d 分钟";
-"about 1 hour" = "大约1小时";
-"about %d hours" = "大约%d 小时";
+"about 1 hour" = "大约 1 小时";
+"about %d hours" = "大约 %d 小时";
 "1 day" = "1 天";
 "%d days" = "%d 天";
-"about 1 month" = "大约1个月";
+"about 1 month" = "大约 1 个月";
 "%d months" = "%d 月";
-"about 1 year" = "大约1年";
-"over %d years" = "超过%d 年";
+"about 1 year" = "大约 1 年";
+"over %d years" = "超过 %d 年";

--- a/SAMCategories/SAMCategories.bundle/zh_Hans.lproj/SAMCategories.strings
+++ b/SAMCategories/SAMCategories.bundle/zh_Hans.lproj/SAMCategories.strings
@@ -14,6 +14,8 @@
 "%dh" = "%d小时";   // several hours
 "1d" = "1天";   // one day
 "%@d" = "%@天";   // several days
+"1y" = "1年";   // one year
+"%@y" = "%@年";   // several years
 
 "1 minute" = "1 分钟";
 "less than %d seconds" = "少于 %d 秒";

--- a/SAMCategories/SAMCategories.bundle/zh_Hant.lproj/SAMCategories.strings
+++ b/SAMCategories/SAMCategories.bundle/zh_Hant.lproj/SAMCategories.strings
@@ -14,6 +14,8 @@
 "%dh" = "%d小時";   // several hours
 "1d" = "1天";   // one day
 "%@d" = "%@天";   // several days
+"1y" = "1年";   // one year
+"%@y" = "%@年";   // several years
 
 "1 minute" = "1 分鐘";
 "less than %d seconds" = "少於 %d 秒";

--- a/SAMCategories/SAMCategories.bundle/zh_Hant.lproj/SAMCategories.strings
+++ b/SAMCategories/SAMCategories.bundle/zh_Hant.lproj/SAMCategories.strings
@@ -15,16 +15,16 @@
 "1d" = "1天";   // one day
 "%@d" = "%@天";   // several days
 
-"1 minute" = "1分鍾";
-"%d minutes" = "少于 %d 秒";
-"half a minute" = "半分鍾";
-"less than a minute" = "少于一分鍾";
-"%d minutes" = "%d 分鍾";
-"about 1 hour" = "大約1小時";
-"about %d hours" = "大約%d 小時";
-"1 day" = "1天";
+"1 minute" = "1 分鐘";
+"less than %d seconds" = "少於 %d 秒";
+"half a minute" = "半分鐘";
+"less than a minute" = "少於一分鐘";
+"%d minutes" = "%d 分鐘";
+"about 1 hour" = "大約 1 小時";
+"about %d hours" = "大約 %d 小時";
+"1 day" = "1 天";
 "%d days" = "%d 天";
-"about 1 month" = "大約1個月";
+"about 1 month" = "大約 1 個月";
 "%d months" = "%d 月";
-"about 1 year" = "大約1年";
-"over %d years" = "超過%d 年";
+"about 1 year" = "大約 1 年";
+"over %d years" = "超過 %d 年";


### PR DESCRIPTION
While using good old SSToolkit (<3), I've noticed that this localized string key looks wrong in several translations:

https://github.com/soffes/sstoolkit/blob/master/Resources/zh_Hant.lproj/SSToolkit.strings#L20

(Even without looking at the translations on the right hand side, it's a duplicate key.)

The more I looked at it, the more seemed odd in these categories :) Will push more commits if I get a chance, but feel free to discuss and merge/reject this already.

Nothing in this PR has been tested manually or automatically, and I have only looked at a few languages so far. I have verified my changes to the Chinese translations with a native speaker though.
